### PR TITLE
Fix a typo in fastcgi-9000 documentation

### DIFF
--- a/network-services-pentesting/9000-pentesting-fastcgi.md
+++ b/network-services-pentesting/9000-pentesting-fastcgi.md
@@ -27,7 +27,7 @@ By default **FastCGI** run in **port** **9000** and isn't recognized by nmap. **
 
 # RCE
 
-It's quiet easy to make FastCGI execute arbitrary code:
+It's quite easy to make FastCGI execute arbitrary code:
 
 ```bash
 #!/bin/bash


### PR DESCRIPTION
Fix a typo in fastcgi-9000 documentation
`quiet -> quite`