### PR TITLE
Clean up subdomain takeover page

### DIFF
--- a/pentesting-web/domain-subdomain-takeover.md
+++ b/pentesting-web/domain-subdomain-takeover.md
@@ -24,42 +24,35 @@ Get Access Today:
 
 ## Domain takeover
 
-If you discover some domain (domain.tld) that is **being used by some service inside the scope** but the **company** has l**o**st the **ownership** of it, you can try to **register** it (if cheap enough) and let know the company. If this domain is receiving some **sensitive information** like a sessions cookie via **GET** parameter or in the **Referer** header, this is for sure a **vulnerability**.
+If you discover some domain (domain.tld) that is **being used by some service inside the scope** but the **company** has **lost ownership** of it, you can try to **register** it (if cheap enough) and let the company know. If this domain is receiving some **sensitive information** like a session cookie via **GET** parameter or in the **Referer** header, this is for sure a **vulnerability**.
 
 ### Subdomain takeover
 
-A subdomain of the company is pointing to a **third-party service with a name not registered**. If you can **create** an **account** in this **third party service** and **register** the **name** being in use, you can perform the subdomain take over.
+A subdomain of the company is pointing to a **third-party service with a name not registered**. If you can **create** an **account** in this **third party service** and **register** the **name** being in use, you can perform the subdomain takeover.
 
 There are several tools with dictionaries to check for possible takeovers:
 
+* [https://github.com/Stratus-Security/Subdominator](https://github.com/Stratus-Security/Subdominator)
 * [https://github.com/EdOverflow/can-i-take-over-xyz](https://github.com/EdOverflow/can-i-take-over-xyz)
-* [https://github.com/blacklanternsecurity/bbot](https://github.com/blacklanternsecurity/bbot)
 * [https://github.com/punk-security/dnsReaper](https://github.com/punk-security/dnsReaper)
-* [https://github.com/haccer/subjack](https://github.com/haccer/subjack)
-* [https://github.com/anshumanbh/tko-sub](https://github.com/anshumanbh/tko-subs)
-* [https://github.com/ArifulProtik/sub-domain-takeover](https://github.com/ArifulProtik/sub-domain-takeover)
-* [https://github.com/SaadAhmedx/Subdomain-Takeover](https://github.com/SaadAhmedx/Subdomain-Takeover)
-* [https://github.com/Ice3man543/SubOver](https://github.com/Ice3man543/SubOver)
-* [https://github.com/m4ll0k/takeover](https://github.com/m4ll0k/takeover)
-* [https://github.com/antichown/subdomain-takeover](https://github.com/antichown/subdomain-takeover)
 * [https://github.com/musana/mx-takeover](https://github.com/musana/mx-takeover)
 * [https://github.com/PentestPad/subzy](https://github.com/PentestPad/subzy)
 
-#### Scanning for Hijackable Subdomains with [BBOT](https://github.com/blacklanternsecurity/bbot):
+#### Scanning for Hijackable Subdomains with [Subdominator](https://github.com/Stratus-Security/Subdominator):
 
-Subdomain takeover checks are included in BBOT's default subdomain enumeration. Signatures are pulled directly from [https://github.com/EdOverflow/can-i-take-over-xyz](https://github.com/EdOverflow/can-i-take-over-xyz).
+Subdominator uses a refined fingerprint schema and intelligent DNS checks to optimize speed and accuracy. Read more about how it works [here](https://www.stratussecurity.com/post/the-ultimate-subdomain-takeover-tool).
 
 ```bash
-bbot -t evilcorp.com -f subdomain-enum
+subdominator -d sub.example.com -o output.txt
 ```
 
 ### Subdomain Takeover Generation via DNS Wildcard
 
 When DNS wildcard is used in a domain, any requested subdomain of that domain that doesn't have a different address explicitly will be **resolved to the same information**. This could be an A ip address, a CNAME...
 
-For example, if `*.testing.com` is wilcarded to `1.1.1.1`. Then, `not-existent.testing.com` will be pointing to `1.1.1.1`.
+For example, if `*.testing.com` is wildcarded to `1.1.1.1`. Then, `not-existent.testing.com` will be pointing to `1.1.1.1`.
 
-However, if instead of pointing to an IP address, the sysadmin point it to a **third party service via CNAME**, like a **github subdomain** for example (`sohomdatta1.github.io`). An attacker could **create his own third party page** (in Gihub in this case) and say that `something.testing.com` is pointing there. Because, the **CNAME wildcard** will agree the attacker will be able to **generate arbitrary subdomains for the domain of the victim pointing to his pages**.
+However, if instead of pointing to an IP address, the sysadmin points it to a **third party service via CNAME**, like a **GitHub subdomain** for example (`sohomdatta1.github.io`). An attacker could **create his own third party page** (in GitHub in this case) and say that `something.testing.com` is pointing there. Because the **CNAME wildcard** will agree, the attacker will be able to **generate arbitrary subdomains for the domain of the victim pointing to his pages**.
 
 You can find an example of this vulnerability in the CTF write-up: [https://ctf.zeyu2001.com/2022/nitectf-2022/undocumented-js-api](https://ctf.zeyu2001.com/2022/nitectf-2022/undocumented-js-api)
 
@@ -102,7 +95,7 @@ For cloud providers, verifying domain ownership is crucial to prevent subdomain 
 ## References
 
 * [https://0xpatrik.com/subdomain-takeover/](https://0xpatrik.com/subdomain-takeover/)
-
+* [https://www.stratussecurity.com/post/subdomain-takeover-guide](https://www.stratussecurity.com/post/subdomain-takeover-guide)
 <figure><img src="../.gitbook/assets/image (48).png" alt=""><figcaption></figcaption></figure>
 
 \


### PR DESCRIPTION
Just a quick PR to tidy up the subdomain takeover page, there were a number of typos and old tools that don't exist or are just not very useful in 2024. Let me know if there's anything that needs to change 😄 
1. **Fix up a bunch of typos and grammar issues**
2. **Add another blog reference**
3. **Add subdomain takeover tool**
4. **Remove extraneous subdomain takeover tools:**
- subover (Discontinued project)
- m4ll0k/takeover (deleted)
- ArifulProtik/sub-domain-takeover (last commit 5 years ago)
- tko-subs (last commit 4 years ago)
- subjack (archived)
- antichown/subdomain-takeover (last updated 5 years ago)
- bbot (no longer checks for takeovers in subdomain-enum)
- SaadAhmedx/Subdomain-Takeover (last updated 6 years ago)

