### PR TITLE
Fix typo in pentesting SMTP/s

### DIFF
--- a/network-services-pentesting/pentesting-smtp/README.md
+++ b/network-services-pentesting/pentesting-smtp/README.md
@@ -203,6 +203,7 @@ swaks --to $(cat emails | tr '\n' ',' | less) --from test@sneakymailer.htb --hea
 <details>
 
 <summary>Pythonコードはこちら</summary>
+
 ```python
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText


### PR DESCRIPTION
Fixed an issue where the text after "Sending an Email with Python" in "pentesting SMTP/s" in the Japanese document was not displayed correctly.