### PR TITLE
Add references to link enumeration and usage in MSSQL Pentesting

### DIFF
--- a/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
+++ b/network-services-pentesting/pentesting-mssql-microsoft-sql-server/README.md
@@ -135,6 +135,11 @@ select sp.name as login, sp.type_desc as login_type, sl.password_hash, sp.create
 #Create user with sysadmin privs
 CREATE LOGIN hacker WITH PASSWORD = 'P@ssword123!'
 EXEC sp_addsrvrolemember 'hacker', 'sysadmin'
+
+#Enumerate links
+enum_links
+#Use a link
+use_link [NAME]
 ```
 
 #### Get User
@@ -454,6 +459,11 @@ WHERE a.permission_name = 'IMPERSONATE'
 EXECUTE AS LOGIN = 'sa'
 SELECT SYSTEM_USER
 SELECT IS_SRVROLEMEMBER('sysadmin')
+
+# If you can't find any users, make sure to check for links
+enum_links
+# If there is a link of interest, re-run the above steps on each link
+use_link [NAME]
 ```
 
 {% hint style="info" %}
@@ -534,6 +544,7 @@ You probably will be able to **escalate to Administrator** following one of thes
 * [https://www.netspi.com/blog/technical/network-penetration-testing/hacking-sql-server-stored-procedures-part-2-user-impersonation/](https://www.netspi.com/blog/technical/network-penetration-testing/hacking-sql-server-stored-procedures-part-2-user-impersonation/)
 * [https://www.netspi.com/blog/technical/network-penetration-testing/executing-smb-relay-attacks-via-sql-server-using-metasploit/](https://www.netspi.com/blog/technical/network-penetration-testing/executing-smb-relay-attacks-via-sql-server-using-metasploit/)
 * [https://blog.waynesheffield.com/wayne/archive/2017/08/working-registry-sql-server/](https://blog.waynesheffield.com/wayne/archive/2017/08/working-registry-sql-server/) **Try Hard Security Group**
+* [https://mayfly277.github.io/posts/GOADv2-pwning-part12/](https://mayfly277.github.io/posts/GOADv2-pwning-part12/)
 
 <figure><img src="../../.gitbook/assets/telegram-cloud-document-1-5159108904864449420.jpg" alt=""><figcaption></figcaption></figure>
 


### PR DESCRIPTION
This adds some small notes to enumeration and usage of links when checking for ways to privilege escalate such as in impersonation and in basic manual enumeration steps.