### PR TITLE
Update double-free.md

### DIFF
--- a/binary-exploitation/libc-heap/double-free.md
+++ b/binary-exploitation/libc-heap/double-free.md
@@ -89,7 +89,7 @@ int main() {
     printf("g1: %p\n", (void *)g1);
     printf("h1: %p\n", (void *)h1);
     printf("i1: %p\n", (void *)i1);
-    printf("i2: %p\n", (void *)i1);
+    printf("i2: %p\n", (void *)i2);
 
     return 0;
 }


### PR DESCRIPTION
I think there is a typo here. If you print out i1, i1 twice, it will end up with the same address twice regardless of double free or not.