### PR TITLE
Update double-free.md

### DIFF
--- a/binary-exploitation/libc-heap/double-free.md
+++ b/binary-exploitation/libc-heap/double-free.md
@@ -89,7 +89,7 @@ int main() {
     printf("g1: %p\n", (void *)g1);
     printf("h1: %p\n", (void *)h1);
     printf("i1: %p\n", (void *)i1);
-    printf("i2: %p\n", (void *)i1);
+    printf("i2: %p\n", (void *)i2);
 
     return 0;
 }


### PR DESCRIPTION
A slight typo here probably. Printing i1 would always result in the same address regardless of the double free.

You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.


Thank you for contributing to HackTricks!
