### PR TITLE
Fixing cut argument on "How to merge splited APKs" trick.

### DIFF
--- a/mobile-pentesting/android-app-pentesting/README.md
+++ b/mobile-pentesting/android-app-pentesting/README.md
@@ -70,7 +70,7 @@ adb pull /data/app/com.android.insecurebankv2-Jnf8pNgwy3QA_U5f-n_4jQ==/base.apk
 
 ```bash
 mkdir splits
-adb shell pm path com.android.insecurebankv2 | cut -d ':' -f 1 | xargs -n1 -i adb pull {} splits
+adb shell pm path com.android.insecurebankv2 | cut -d ':' -f 2 | xargs -n1 -i adb pull {} splits
 java -jar ../APKEditor.jar m -i splits/ -o merged.apk
 
 # after merging, you will need to align and sign the apk, personally, I like to use the uberapksigner


### PR DESCRIPTION
My previous submitted trick on #866  was with a wrong command at the cut pipeline.
Fixing in this PR.