### PR TITLE
Typo correction at android-applications-basics.md

### DIFF
--- a/mobile-pentesting/android-app-pentesting/android-applications-basics.md
+++ b/mobile-pentesting/android-app-pentesting/android-applications-basics.md
@@ -224,7 +224,7 @@ The scheme must be declarated in the **`AndroidManifest.xml`** file:
 [...]
 ```
 
-The scheme from the previous example is `exampleapp://` (note also the **`category BROWSABLE`**)
+The scheme from the previous example is `examplescheme://` (note also the **`category BROWSABLE`**)
 
 Then, in the data field, you can specify the **host** and **path**:
 


### PR DESCRIPTION
Fix typo of the deeplink scheme from `exampleapp://` to `examplescheme://` 