### PR TITLE
Fix typo in pentesting-methodology.md

### DIFF
--- a/generic-methodologies-and-resources/pentesting-methodology.md
+++ b/generic-methodologies-and-resources/pentesting-methodology.md
@@ -87,7 +87,7 @@ If you have troubles with the shell, you can find here a small **compilation of 
 
 * [**Linux**](../linux-hardening/useful-linux-commands.md)
 * [**Windows (CMD)**](../windows-hardening/basic-cmd-for-pentesters.md)
-* [**Winodows (PS)**](../windows-hardening/basic-powershell-for-pentesters/)
+* [**Windows (PS)**](../windows-hardening/basic-powershell-for-pentesters/)
 
 ### **9 -** [**Exfiltration**](exfiltration.md)
 


### PR DESCRIPTION
Fixed typo in pentesting-methodology.md where "Winodows" was misspelled.
The correct spelling "Windows" has been updated.