### PR TITLE
Fix typo in pentesting-methodology.md

### DIFF
--- a/generic-methodologies-and-resources/pentesting-methodology.md
+++ b/generic-methodologies-and-resources/pentesting-methodology.md
@@ -121,7 +121,7 @@ Find here different ways to [**dump passwords in Windows**](https://github.com/c
 
 #### 11.2 - Persistence
 
-**Use 2 o 3 different types of persistence mechanism so you won't need to exploit the system again.**\
+**Use 2 or 3 different types of persistence mechanism so you won't need to exploit the system again.**\
 **Here you can find some** [**persistence tricks on active directory**](../windows-hardening/active-directory-methodology/#persistence)**.**
 
 TODO: Complete persistence Post in Windows & Linux


### PR DESCRIPTION
Fixed typo in pentesting-methodology.md where "o" was misspelled.
The correct spelling "or" has been updated.