### PR TITLE
docs(namespaces): add missing code block and nsenter examples

### DIFF
--- a/linux-hardening/privilege-escalation/docker-security/namespaces/time-namespace.md
+++ b/linux-hardening/privilege-escalation/docker-security/namespaces/time-namespace.md
@@ -89,6 +89,7 @@ sudo find /proc -maxdepth 3 -type l -name time -exec ls -l  {} \; 2>/dev/null | 
 ```bash
 nsenter -T TARGET_PID --pid /bin/bash
 ```
+
 {% hint style="success" %}
 Learn & practice AWS Hacking:<img src="/.gitbook/assets/arte.png" alt="" data-size="line">[**HackTricks Training AWS Red Team Expert (ARTE)**](https://training.hacktricks.xyz/courses/arte)<img src="/.gitbook/assets/arte.png" alt="" data-size="line">\
 Learn & practice GCP Hacking: <img src="/.gitbook/assets/grte.png" alt="" data-size="line">[**HackTricks Training GCP Red Team Expert (GRTE)**<img src="/.gitbook/assets/grte.png" alt="" data-size="line">](https://training.hacktricks.xyz/courses/grte)

--- a/linux-hardening/privilege-escalation/docker-security/namespaces/user-namespace.md
+++ b/linux-hardening/privilege-escalation/docker-security/namespaces/user-namespace.md
@@ -165,6 +165,8 @@ Probando: 0x130 . . . Error
 Probando: 0x139 . . . Error
 Probando: 0x140 . . . Error
 Probando: 0x141 . . . Error
+```
+
 {% hint style="success" %}
 Learn & practice AWS Hacking:<img src="/.gitbook/assets/arte.png" alt="" data-size="line">[**HackTricks Training AWS Red Team Expert (ARTE)**](https://training.hacktricks.xyz/courses/arte)<img src="/.gitbook/assets/arte.png" alt="" data-size="line">\
 Learn & practice GCP Hacking: <img src="/.gitbook/assets/grte.png" alt="" data-size="line">[**HackTricks Training GCP Red Team Expert (GRTE)**<img src="/.gitbook/assets/grte.png" alt="" data-size="line">](https://training.hacktricks.xyz/courses/grte)

--- a/linux-hardening/privilege-escalation/docker-security/namespaces/uts-namespace.md
+++ b/linux-hardening/privilege-escalation/docker-security/namespaces/uts-namespace.md
@@ -100,6 +100,9 @@ sudo find /proc -maxdepth 3 -type l -name uts -exec ls -l  {} \; 2>/dev/null | g
 ### Enter inside an UTS namespace
 
 ```bash
+nsenter -u TARGET_PID --pid /bin/bash
+```
+
 {% hint style="success" %}
 Learn & practice AWS Hacking:<img src="/.gitbook/assets/arte.png" alt="" data-size="line">[**HackTricks Training AWS Red Team Expert (ARTE)**](https://training.hacktricks.xyz/courses/arte)<img src="/.gitbook/assets/arte.png" alt="" data-size="line">\
 Learn & practice GCP Hacking: <img src="/.gitbook/assets/grte.png" alt="" data-size="line">[**HackTricks Training GCP Red Team Expert (GRTE)**<img src="/.gitbook/assets/grte.png" alt="" data-size="line">](https://training.hacktricks.xyz/courses/grte)


### PR DESCRIPTION
This PR fixes three guides on namespaces by adding missing code block closure and code examples.
