### PR TITLE
Add autoVolatility3 memory forensics automation guide

### DIFF
--- a/generic-methodologies-and-resources/basic-forensic-methodology/memory-dump-analysis/volatility-cheatsheet.md
+++ b/generic-methodologies-and-resources/basic-forensic-methodology/memory-dump-analysis/volatility-cheatsheet.md
@@ -22,12 +22,26 @@ Learn & practice GCP Hacking: <img src="/.gitbook/assets/grte.png" alt="" data-s
 ​​[**RootedCON**](https://www.rootedcon.com/) is the most relevant cybersecurity event in **Spain** and one of the most important in **Europe**. With **the mission of promoting technical knowledge**, this congress is a boiling meeting point for technology and cybersecurity professionals in every discipline.
 
 {% embed url="https://www.rootedcon.com/" %}
+If you need a tool that automates memory analysis with different scan levels and runs multiple Volatility3 plugins in parallel, you can use autoVolatility3:: [https://github.com/H3xKatana/autoVolatility3/](https://github.com/H3xKatana/autoVolatility3/)
+
+```bash
+# Full scan (runs all plugins)
+python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s full
+
+# Minimal scan (runs a limited set of plugins)
+python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s minimal
+
+# Normal scan (runs a balanced set of plugins)
+python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s normal
+
+```
 
 If you want something **fast and crazy** that will launch several Volatility plugins on parallel you can use: [https://github.com/carlospolop/autoVolatility](https://github.com/carlospolop/autoVolatility)
 
 ```bash
 python autoVolatility.py -f MEMFILE -d OUT_DIRECTORY -e /home/user/tools/volatility/vol.py # It will use the most important plugins (could use a lot of space depending on the size of the memory)
 ```
+
 
 ## Installation
 

--- a/generic-methodologies-and-resources/basic-forensic-methodology/memory-dump-analysis/volatility-cheatsheet.md
+++ b/generic-methodologies-and-resources/basic-forensic-methodology/memory-dump-analysis/volatility-cheatsheet.md
@@ -26,13 +26,13 @@ If you need a tool that automates memory analysis with different scan levels and
 
 ```bash
 # Full scan (runs all plugins)
-python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s full
+python3 autovol3.py -f MEMFILE -o OUT_DIR -s full
 
 # Minimal scan (runs a limited set of plugins)
-python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s minimal
+python3 autovol3.py -f MEMFILE -o OUT_DIR -s minimal
 
 # Normal scan (runs a balanced set of plugins)
-python3 volatility_forensics.py -f MEMFILE -o OUT_DIR -s normal
+python3 autovol3.py -f MEMFILE -o OUT_DIR -s normal
 
 ```
 


### PR DESCRIPTION


i added in this pull  request about  guide for autoVolatility3, a tool that automates memory forensics by running multiple Volatility3 plugins in parallel with different scan levels. and The guide includes:

    A brief explanation of the tool’s purpose.
    Example commands for running full, minimal, and normal scan levels.
    A link to the official repository for further reference.