### PR TITLE
docs: fix AMQP service heading level in brute-force.md

### DIFF
--- a/src/generic-hacking/brute-force.md
+++ b/src/generic-hacking/brute-force.md
@@ -117,7 +117,7 @@ msf> run
 nmap --script ajp-brute -p 8009 <IP>
 ```
 
-## AMQP (ActiveMQ, RabbitMQ, Qpid, JORAM and Solace)
+### AMQP (ActiveMQ, RabbitMQ, Qpid, JORAM and Solace)
 
 ```bash
 legba amqp --target localhost:5672 --username admin --password data/passwords.txt [--amql-ssl]


### PR DESCRIPTION
The `services` section uses `##` and all the subsections under it use `###`.

Unlike others AMQP currently uses `##`.




