### PR TITLE
Correct sudo versions vulnerable to CVE-2019-14287

### DIFF
--- a/src/linux-hardening/privilege-escalation/README.md
+++ b/src/linux-hardening/privilege-escalation/README.md
@@ -83,7 +83,7 @@ You can check if the sudo version is vulnerable using this grep.
 sudo -V | grep "Sudo ver" | grep "1\.[01234567]\.[0-9]\+\|1\.8\.1[0-9]\*\|1\.8\.2[01234567]"
 ```
 
-#### sudo < v1.28
+#### sudo < v1.8.28
 
 From @sickrov
 


### PR DESCRIPTION
sudo<1.8.28 is vunerable  : https://ubuntu.com/security/CVE-2019-14287

You can remove this content before sending the PR:

## Attribution
We value your knowledge and encourage you to share content. Please ensure that you only upload content that you own or that have permission to share it from the original author (adding a reference to the author in the added text or at the end of the page you are modifying or both). Your respect for intellectual property rights fosters a trustworthy and legal sharing environment for everyone.


Thank you for contributing to HackTricks!




