### PR TITLE
Add serial-in-SSID PSK, Telnet PSK leak & cloud IDOR vectors (GivEnergy battery gateways)

### DIFF
--- a/src/generic-methodologies-and-resources/pentesting-wifi/README.md
+++ b/src/generic-methodologies-and-resources/pentesting-wifi/README.md
@@ -1062,6 +1062,33 @@ Some consumer IoT relays/controllers keep the commissioning **open AP** active a
 
 For persistence, leave the commissioning AP enabled.<sup>[[2]](#references)</sup>
 
+## Broadcast-derived PSKs and management-plane credential pivot
+
+Treat every value advertised before authentication—SSID, BSSID, model and serial-like suffixes—as public input. Check whether the commissioning AP uses a fixed PSK, the device serial, or a deterministic transformation of one of these values. In one battery-gateway deployment, legacy units used `12345678`, while later guidance reused an inverter serial already embedded in an SSID such as `WK12345G67`; association therefore required no WPA handshake cracking. Searching authorized wardriving datasets for the SSID pattern may also correlate an identifier with a location, although exploitation still needs radio proximity or another route to the gateway.<sup>[[30]](#references)</sup>
+
+A gateway that keeps its AP active while operating as a **station (STA)** on a trusted WLAN—or while connected to that LAN by Ethernet—is a cross-zone pivot candidate. Do not assume it routes packets between interfaces: first inspect AP-side Telnet/HTTP/API configuration for plaintext STA PSKs, exported configuration, cloud credentials, or a scripting/request primitive. In the reported chain, default `admin`/`admin` Telnet access exposed the PSK of the trusted WLAN, allowing the attacker to leave the commissioning network and authenticate directly to the home network.<sup>[[30]](#references)</sup>
+
+A low-impact authorized workflow is:<sup>[[30]](#references)</sup>
+
+1. Capture beacons passively and compare the SSID with labels, manuals, QR data and other public device identifiers. Test only the small set of documented/default derivations before attempting conventional WPA cracking.
+2. After joining the AP, identify its gateway and probe likely management ports individually and slowly; embedded stacks may not tolerate a normal high-rate scan.
+
+   ```bash
+   ip route | grep default
+   for p in 23 80 502 8099 8899; do
+       nc -nvz -w 2 <gateway_ip> "$p"
+       sleep 1
+   done
+   ```
+
+3. Try documented/default credentials with very few attempts, then enumerate **read-only configuration first**. Treat stored station credentials as a higher-trust secret even though they are exposed through the lower-trust AP.
+4. Determine whether the compromise yields (a) a reusable STA PSK, (b) direct Ethernet/L3 reachability, or (c) only an application-layer egress primitive. Validate a pivot with a controlled host rather than scanning the trusted LAN.
+5. Continue service-specific testing in [Pentesting Telnet](../../network-services-pentesting/pentesting-telnet.md) and [Pentesting Modbus](../../network-services-pentesting/pentesting-modbus.md). For cloud APIs, reuse two accounts you control and substitute only the device identifier as described in [IDOR/BOLA testing](../../pentesting-web/idor.md); a serial number is an object selector, not proof of ownership.
+
+### Scan-triggered reset as a destructive primitive
+
+On resource-constrained gateways, enumeration itself can become a state-changing attack: a request burst or aggressive port scan may crash the network module, and recovery may restore factory defaults rather than merely reboot it. Before stress testing in a lab, record the SSID/authentication mode, DHCP behavior, uptime and configuration; maintain physical recovery access; then increase only one rate or protocol variable at a time. Loss of ARP/management responses followed by a default SSID, default credentials or erased settings confirms a reset/DoS boundary and should stop further scanning.<sup>[[30]](#references)</sup>
+
 ## References
 
 - [1] [Wifiphisher - The Rogue Access Point Framework](https://github.com/wifiphisher/wifiphisher)
@@ -1093,5 +1120,6 @@ For persistence, leave the commissioning AP enabled.<sup>[[2]](#references)</sup
 - [27] [en.wikipedia.org - Extensible Authentication Protocol](https://en.wikipedia.org/wiki/Extensible_Authentication_Protocol)
 - [28] [intel.com - Network And I O - Wireless Networking](https://www.intel.com/content/www/us/en/support/articles/000006999/network-and-i-o/wireless-networking.html)
 - [29] [interlinknetworks.com - App Notes - Eap Peap](https://www.interlinknetworks.com/app_notes/eap-peap.htm)
+- [30] [GivEnergy enters administration, batteries expose home networks](https://pentestpartners.com/security-blog/givenergy-enters-administration-legacy-home-batteries-still-expose-customer-networks)
 
 {{#include ../../banners/hacktricks-training.md}}

--- a/src/generic-methodologies-and-resources/pentesting-wifi/README.md
+++ b/src/generic-methodologies-and-resources/pentesting-wifi/README.md
@@ -1062,32 +1062,66 @@ Some consumer IoT relays/controllers keep the commissioning **open AP** active a
 
 For persistence, leave the commissioning AP enabled.<sup>[[2]](#references)</sup>
 
-## Broadcast-derived PSKs and management-plane credential pivot
+## Serial-in-SSID PSKs & dual-homed battery gateways (GivEnergy AIO case)
 
-Treat every value advertised before authentication—SSID, BSSID, model and serial-like suffixes—as public input. Check whether the commissioning AP uses a fixed PSK, the device serial, or a deterministic transformation of one of these values. In one battery-gateway deployment, legacy units used `12345678`, while later guidance reused an inverter serial already embedded in an SSID such as `WK12345G67`; association therefore required no WPA handshake cracking. Searching authorized wardriving datasets for the SSID pattern may also correlate an identifier with a location, although exploitation still needs radio proximity or another route to the gateway.<sup>[[30]](#references)</sup>
+Many IoT gateways broadcast their serial in the SSID **and** derive the WPA PSK from that same serial, so the wireless password is readable from the air with no handshake capture or cracking. GivEnergy "All In One" battery gateways show the full chain, from Wi-Fi association to a foothold on the customer's home LAN and access to any customer's cloud data.<sup>[[30]](#references)</sup>
 
-A gateway that keeps its AP active while operating as a **station (STA)** on a trusted WLAN—or while connected to that LAN by Ethernet—is a cross-zone pivot candidate. Do not assume it routes packets between interfaces: first inspect AP-side Telnet/HTTP/API configuration for plaintext STA PSKs, exported configuration, cloud credentials, or a scripting/request primitive. In the reported chain, default `admin`/`admin` Telnet access exposed the PSK of the trusted WLAN, allowing the attacker to leave the commissioning network and authenticate directly to the home network.<sup>[[30]](#references)</sup>
+### 1. Recover the AP PSK from the SSID
 
-A low-impact authorized workflow is:<sup>[[30]](#references)</sup>
+The gateway advertises an SSID of the form `WK<SERIAL>` (e.g. `WK12345G67`), and:
 
-1. Capture beacons passively and compare the SSID with labels, manuals, QR data and other public device identifiers. Test only the small set of documented/default derivations before attempting conventional WPA cracking.
-2. After joining the AP, identify its gateway and probe likely management ports individually and slowly; embedded stacks may not tolerate a normal high-rate scan.
+- Older units shipped a fixed PSK of `12345678`.
+- The installer manual then told installers to **use the inverter serial number as the Wi-Fi password** — but that serial is already inside the broadcast SSID.
 
-   ```bash
-   ip route | grep default
-   for p in 23 80 502 8099 8899; do
-       nc -nvz -w 2 <gateway_ip> "$p"
-       sleep 1
-   done
-   ```
+So you associate to the commissioning AP just by reading its name; there is no WPA4-way handshake to crack. Because the SSID pattern is fixed, you can pre-locate targets by searching wardriving datasets (e.g. wigle.net) for the `WK` prefix, though exploitation still needs radio proximity or another route to the gateway.
 
-3. Try documented/default credentials with very few attempts, then enumerate **read-only configuration first**. Treat stored station credentials as a higher-trust secret even though they are exposed through the lower-trust AP.
-4. Determine whether the compromise yields (a) a reusable STA PSK, (b) direct Ethernet/L3 reachability, or (c) only an application-layer egress primitive. Validate a pivot with a controlled host rather than scanning the trusted LAN.
-5. Continue service-specific testing in [Pentesting Telnet](../../network-services-pentesting/pentesting-telnet.md) and [Pentesting Modbus](../../network-services-pentesting/pentesting-modbus.md). For cloud APIs, reuse two accounts you control and substitute only the device identifier as described in [IDOR/BOLA testing](../../pentesting-web/idor.md); a serial number is an object selector, not proof of ownership.
+### 2. Telnet admin/admin on the Wi-Fi module → steal the home Wi-Fi PSK
 
-### Scan-triggered reset as a destructive primitive
+The device is **dual-homed**: it keeps its own AP up while also joining the customer's home WLAN as a station (STA), and installers are told to additionally cable its RJ45 to the home router when close. Once on the AP side, the embedded **Hi-Flying HF-A21-SMT** Wi-Fi module exposes its own management surface:
 
-On resource-constrained gateways, enumeration itself can become a state-changing attack: a request burst or aggressive port scan may crash the network module, and recovery may restore factory defaults rather than merely reboot it. Before stress testing in a lab, record the SSID/authentication mode, DHCP behavior, uptime and configuration; maintain physical recovery access; then increase only one rate or protocol variable at a time. Loss of ARP/management responses followed by a default SSID, default credentials or erased settings confirms a reset/DoS boundary and should stop further scanning.<sup>[[30]](#references)</sup>
+| Service | Port | Notes |
+|---|---|---|
+| Telnet | 23 | HF-A21 module console, default `admin`/`admin` |
+| HTTP | 80 | Embedded web server, default `admin`/`admin` |
+| Modbus TCP | 502 | Battery control |
+| Vendor API | 8099 / 8899 | Battery control / data |
+
+Logging into Telnet with `admin`/`admin` gives commands that dump the module configuration **including the home WLAN PSK in cleartext** (the same class of bug as the 2015 iKettle). At that point you drop off the commissioning AP and authenticate straight onto the victim's home network — or just use the Ethernet bridge if it was cabled in.
+
+```bash
+# after joining the WK<serial> AP and getting a lease
+ip route | grep default              # find the gateway/module IP
+telnet <module_ip> 23                # admin / admin, then read the STA config for the home PSK
+```
+
+### 3. Battery control via Modbus/API
+
+Reaching the module also exposes the battery-control plane on Modbus TCP `502` and the vendor API on `8099`, which can **force the battery not to charge/discharge**, rendering it useless. Continue in [Pentesting Modbus](../../network-services-pentesting/pentesting-modbus.md) and [Pentesting Telnet](../../network-services-pentesting/pentesting-telnet.md).
+
+### 4. Cloud IDOR: serial number as an object selector
+
+The serial you read from the SSID also unlocks other customers' data in the vendor cloud. The internal API took the serial straight from the path with no ownership check:
+
+```http
+GET /internal-api/inverter/data/CH12345678/2024-05-23
+```
+
+Swapping the serial returns another customer's grid power, voltage, generation, consumption, battery state and export data. A serial number is an **object selector, not proof of ownership** — test it as a classic IDOR/BOLA with two accounts you control, see [IDOR/BOLA testing](../../pentesting-web/idor.md).
+
+### 5. Port scan = factory reset (destructive DoS)
+
+The HF-A21 network stack is fragile: **a normal aggressive port scan can crash the module, and it comes back at factory defaults** rather than merely rebooting — wiping charge/discharge config and reverting to the default SSID/credentials. Two consequences for testing:
+
+- Probe embedded gateways **one port at a time and slowly**, not with a full-rate `nmap`:
+
+  ```bash
+  for p in 23 80 502 8099 8899; do
+      nc -nvz -w 2 <gateway_ip> "$p"
+      sleep 1
+  done
+  ```
+
+- If ARP/management responses drop and a default SSID or default credentials reappear, you have hit the reset/DoS boundary — record state beforehand and keep physical recovery access.
 
 ## References
 


### PR DESCRIPTION
## What this adds

A new section in **Pentesting Wi-Fi** documenting the IoT battery-gateway attack chain from the GivEnergy "All In One" research, written as concrete, reusable attack vectors (not device trivia).

**Section:** `src/generic-methodologies-and-resources/pentesting-wifi/README.md` → *Serial-in-SSID PSKs & dual-homed battery gateways (GivEnergy AIO case)*

### Attack vectors covered

1. **Serial-in-SSID → WPA PSK.** The gateway broadcasts `WK<SERIAL>` and derives the WPA PSK from that same serial (or ships the fixed `12345678`), so the wireless password is recoverable from the beacon with no handshake capture or cracking. SSID pattern is also searchable in wardriving datasets (wigle.net) to pre-locate targets.
2. **Telnet/HTTP `admin`/`admin` on the Hi-Flying HF-A21-SMT module → home Wi-Fi PSK in cleartext.** The dual-homed gateway (own AP + STA on the home WLAN, plus optional RJ45 bridge) exposes a module console whose config dump leaks the customer's home WLAN PSK, pivoting the attacker onto the home LAN (same class as the 2015 iKettle bug).
3. **Battery control via Modbus TCP `502` / vendor API `8099`** — force the battery to stop charging/discharging.
4. **Cloud IDOR / BOLA** — `GET /internal-api/inverter/data/<serial>/<date>` takes the serial straight from the path with no ownership check; swapping the serial (read from the SSID) returns any customer's grid/generation/consumption/battery data.
5. **Port scan = factory reset (destructive DoS)** — the fragile module crashes to factory defaults under an aggressive scan, wiping config; guidance to probe one port at a time and record state first.

Cross-references to [Pentesting Telnet](../../network-services-pentesting/pentesting-telnet.md), [Pentesting Modbus](../../network-services-pentesting/pentesting-modbus.md), and [IDOR/BOLA](../../pentesting-web/idor.md). Reference `[30]`.

### Note
Rewritten from the original auto-generated draft, which described these as abstract "management-plane pivot" methodology and dropped the concrete values (SSID→PSK derivation, `admin/admin`, the module name, the IDOR URL, the Modbus/API control plane).

Source: https://pentestpartners.com/security-blog/givenergy-enters-administration-legacy-home-batteries-still-expose-customer-networks
