### PR TITLE
Add StackScan to Trackers in external recon methodology

### DIFF
--- a/src/generic-methodologies-and-resources/external-recon-methodology/README.md
+++ b/src/generic-methodologies-and-resources/external-recon-methodology/README.md
@@ -124,6 +124,16 @@ There are some pages and tools that let you search by these trackers and more:
 - [**Publicwww**](https://publicwww.com)
 - [**SpyOnWeb**](http://spyonweb.com)
 - [**Webscout**](https://github.com/straightblast/Sc0ut) (finds related sites by shared analytics/trackers)
+- [**StackScan**](https://www.stackscan.com) - **Free tier** (Web and API). Pivot on any served asset, not just tracker IDs: a script path, a self-hosted bundle name, or the host an asset loads from, returning every site carrying it
+
+The API returns the stack for a single domain, which is useful for confirming a candidate asset belongs to the same estate:
+
+```bash
+curl -H "Authorization: Bearer $TOKEN" -H "X-Tenant-Id: $WORKSPACE" \
+  "https://api.stackscan.com/v1/tech-lookup/domains/lookup?domain=tesla.com"
+```
+
+Returns each detected technology with its category. Asset pivoting is currently web only, the API covers per-domain lookup.
 
 ### **Favicon**
 


### PR DESCRIPTION
Adds StackScan to **Trackers** in the external recon methodology.

**Disclosure: I work on StackScan.**

The section's premise is pivoting on a shared identifier to find sites run by the same team. StackScan generalises that past tracker IDs to any served asset: give it a file name, a script path, or the host an asset loads from, and it returns every site carrying that footprint. That catches self-hosted bundles, internal SDKs and one-off script paths, none of which have a tracker ID or a named detector.

Also added the API call for per-domain stack lookup, verified against tesla.com (33 technologies returned). Asset pivoting is web only and the text says so, so nobody goes looking for an endpoint that is not there.

Free tier on email verification: 100 lifetime API credits, one list, and custom footprint scans.
