### PR TITLE
Add Malwagon to Online Services in malware analysis

### DIFF
--- a/src/generic-methodologies-and-resources/basic-forensic-methodology/malware-analysis.md
+++ b/src/generic-methodologies-and-resources/basic-forensic-methodology/malware-analysis.md
@@ -13,6 +13,7 @@
 - [Koodous](https://koodous.com)
 - [Intezer](https://analyze.intezer.com)
 - [Any.Run](https://any.run/)
+- [Malwagon](https://malwagon.com)
 
 ## Offline Antivirus and Detection Tools
 


### PR DESCRIPTION
Adds [Malwagon](https://malwagon.com) to the Online Services list on the malware analysis page, beside the other hosted sandboxes already there.

Disclosure: I work on Malwagon, so this is a vendor submission.

It detonates a submitted file or URL on instrumented Windows and Linux virtual machines and returns the process tree, registry and file activity, network traffic, extracted indicators and ATT&CK technique mappings. A report for a public scan is readable without an account, for example https://malwagon.com/s/2366

There is a free community tier: an API key is issued without payment details, so a reader of this page can use it. Submitting a sample and the MCP server are on paid plans; the hash lookup and indicator search reach the free tier. I have written that out rather than calling it simply free.

Single line, matching the plain `- [Name](url)` format the section uses, appended after Any.Run since the list is not alphabetical.